### PR TITLE
Linked the "Publish 3D models" button to the free popup order

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -14,7 +14,7 @@ block content
         br
         <svg class="spacer" xmlns="http://www.w3.org/2000/svg" style="width:100%;" viewBox="0 0 500 50"></svg>
         a(href='https://appcreator.3d.io/').cta-button Build apps
-        a(href='https://spaces.archilogic.com/order').cta-button Publish 3d models
+        a(href='https://spaces.archilogic.com/explore?popup=order').cta-button Publish 3d models
         a(href='https://github.com/archilogic-com/3dio-js' title='github').cta-button.cta-github &nbsp;
 
       .six.columns


### PR DESCRIPTION
new link to popup order: https://spaces.archilogic.com/explore?popup=order 
This link will be first released in the next release