### PR TITLE
Google Analytics onclick tracking for partners

### DIFF
--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', '"+partner"');")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click',{'page':'"+ partner.filename +"'});")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,8 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename)
-          a(onClick="ga('send', 'event', '3dio_partners', 'click', {'page': '"+ partner + "'});")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', {'page': '"+ partner + "'});")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', {'page': '"+ partner + "'});")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', '"partner"');")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', '{"partner"}');")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', {{"partner"}});")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click',{'"+ partner.filename +"'});")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click',{{'"+ partner.filename +"'}});")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click',{{'"+ partner.filename +"'}});")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click','"+ partner.filename +"');")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', '"partner"');")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', '{"partner"}');")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -29,6 +29,7 @@ block content
       .four.columns
         .partner
           a(href='/partner/'+partner.filename)
+          a(onClick="ga('send', 'event', '3dio_partners', 'click', {'page': '"+ partner + "'});")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', {{"partner"}});")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click', '"+partner"');")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)

--- a/src/partners.pug
+++ b/src/partners.pug
@@ -28,7 +28,7 @@ block content
     mixin partner(partner)
       .four.columns
         .partner
-          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click',{'page':'"+ partner.filename +"'});")
+          a(href='/partner/'+partner.filename, onClick="ga('send', 'event', '3dio_partners', 'click',{'"+ partner.filename +"'});")
             //-p= partner.TAGLINE
             .logo-container
               .bg(style=`background:${partner.LOGO_BG_COLOR};`)


### PR DESCRIPTION
**Goal:** 
Adding Google Analytics Event Tracking on Partners page, to see which partner is clicked the most

**steps**:
click on one of the logos on the new partner page  https://3d.io/partners.html 

**Expected result:** => trigger event in GA
- category: "3dio_partners"
- Action: "click"
- Label: name of the partner eg. "aurelien-martel"

**Code based on** : https://github.com/pugjs/pug/issues/1841
**GA tracking documentation**: https://developers.google.com/analytics/devguides/collection/analyticsjs/events