### PR TITLE
[Issue #27] Mailto Subject Lines

### DIFF
--- a/src/partner-application.md
+++ b/src/partner-application.md
@@ -33,4 +33,4 @@
 
 ## Apply Now
 
-[Apply for Certified Partner Program](mailto:partner@archilogic.com)
+[Apply for Certified Partner Program](mailto:partner@archilogic.com?subject=Partner Program Application)

--- a/src/pug-common/footer.pug
+++ b/src/pug-common/footer.pug
@@ -14,7 +14,7 @@
         br
         a(href='https://github.com/archilogic-com/3d-io-website/issues/new?title=Bug: …&body=How to reproduce:%0A1. …%0A2.%0A3.%0A%0AExpected Result:%0A…%0A%0AActual Result:%0A…') Report a bug.
         br
-        a(href='mailto:dev.rocks@archilogic.com') Drop us a line.
+        a(href='mailto:dev.rocks@archilogic.com?subject=Dropping a Line from 3D.io') Drop us a line.
         br
         .social
           a(href='https://github.com/archilogic-com?type=source')

--- a/src/pug-common/partner-profile-page.pug
+++ b/src/pug-common/partner-profile-page.pug
@@ -21,7 +21,7 @@ block content
         if partner.DESCRIPTION
           .description!=partner.DESCRIPTION
         .badges
-          a(href='mailto:'+partner.EMAIL target='_blank' onclick="ga('send', 'event', '3dio_partner_page', 'click_email','"+ partner.NAME +"');").badge.contact Email
+          a(href='mailto:'+partner.EMAIL+'?subject=3D.io Partner Contact' target='_blank' onclick="ga('send', 'event', '3dio_partner_page', 'click_email','"+ partner.NAME +"');").badge.contact Email
           if partner.URL
             div(onclick="ga('send', 'event', '3dio_partner_page', 'click_url','"+ partner.NAME +"');" style="display:inline")
               a(href=partner.URL target="_blank").badge.website Website

--- a/src/special-pricing.md
+++ b/src/special-pricing.md
@@ -3,4 +3,4 @@
 We provide special pricing for:
 
 * [Certified partners](partner-application.md)
-* [Platforms/ large enterprises](mailto:sales@archilogic.com)
+* [Platforms/ large enterprises](mailto:sales@archilogic.com?subject=Enterprise Pricing Inquiry)


### PR DESCRIPTION
Adding context-based subject lines to all mailto: links.
Spot-checked links using 'dev' build and appear to be functioning.