### PR TITLE
Adds icons and hover effect to anchored headlines.

### DIFF
--- a/src/css/md-wrapper.less
+++ b/src/css/md-wrapper.less
@@ -52,8 +52,31 @@
 
     .h-link {
         text-decoration: none;
+        & h2:after {
+            content: url('data:image/svg+xml;utf8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>');
+            display: inline-block;
+            height: auto;
+            margin-left: 0.2em;
+            margin-right: 0;
+            opacity: 0.4;
+            position: relative;
+            transform: rotate(315deg);
+            vertical-align: middle;
+            white-space: nowrap;
+            width: 0.5em;
+        }
+        & *,
+        & h2:after {
+            transition: all 200ms ease-in-out;
+        }
         &:hover {
             text-decoration: none;
+        }
+        &:hover *{
+            color: #4678BC;
+        }
+        &:hover h2:after {
+            opacity: 0.8;
         }
     }
 


### PR DESCRIPTION
Here is my suggestion.

- Turn all headlines blue on hover. I reused the link color.
- Add a link icon to all `h2` but none of the other `h` tags to make the anchors easily discoverable without cluttering the page. I used the material design icon because that was easy to find but am happy to change that.

The one thing I have not figured out yet is how to elegantly prevent the icon from breaking the line.

Thanks for your comments! 💟 

### Normal state
<img width="1018" alt="screenshot 2017-10-20 14 33 08" src="https://user-images.githubusercontent.com/1913615/31821430-626f6868-b5a5-11e7-94c6-1380398ef3ec.png">

### Hover over `h2`
<img width="1018" alt="screenshot 2017-10-20 14 33 46" src="https://user-images.githubusercontent.com/1913615/31821454-7390a8fa-b5a5-11e7-83fb-888259e415f6.png">

### Hover over `h3`
<img width="1018" alt="screenshot 2017-10-20 14 33 39" src="https://user-images.githubusercontent.com/1913615/31821481-8c0f5b74-b5a5-11e7-948d-72ed9c11b834.png">

#22 