### PR TITLE
Fix undefined link glitch

### DIFF
--- a/src/docs/api/1/storage.md
+++ b/src/docs/api/1/storage.md
@@ -56,7 +56,7 @@ io3d.storage.put(file).then(function (key) {
 
 ### Permanent uploads
 
-You can upload files to be permanently stored by using your [publishable key]().
+You can upload files to be permanently stored by using your <a class="open-publishable-api-keys-menu">publishable key</a>.
 
 ```javascript
 var file = new Blob(['Hello World'])
@@ -69,7 +69,7 @@ io3d.storage.put(file).then(function (key) {
 
 ### Permanent uploads with a custom key
 
-You can upload files with a custom key of your choice under your userId using your [secret key]() for the upload or use `io3d.auth.login`.
+You can upload files with a custom key of your choice under your userId using your <a class="open-secret-api-keys-menu">secret key</a> for the upload or use `io3d.auth.login`.
 
 
 ## File Upload


### PR DESCRIPTION
This should fix a glitch with empty links, which was causing them to appear like `undefinedpublishable key`.

See https://3d.io/docs/api/1/storage.html#permanent-uploads

 ![screen shot 2017-11-14 at 18 49 07](https://user-images.githubusercontent.com/1694288/32795923-7fd92e1c-c96d-11e7-9d46-b315f6579fd3.png) 